### PR TITLE
不要セミコロンの削除

### DIFF
--- a/input/src/main/scala/fix/UnnecessarySemicolon.scala
+++ b/input/src/main/scala/fix/UnnecessarySemicolon.scala
@@ -1,0 +1,11 @@
+/*
+rule = UnnecessarySemicolon
+*/
+package fix
+
+object UnnecessarySemicolon {
+  val x = 3;
+  println(x)
+
+  val a = 1; val b = 2
+};

--- a/input/src/main/scala/fix/pixiv/UnnecessarySemicolon.scala
+++ b/input/src/main/scala/fix/pixiv/UnnecessarySemicolon.scala
@@ -1,7 +1,10 @@
-package fix
+/*
+rule = UnnecessarySemicolon
+ */
+package fix.pixiv
 
 object UnnecessarySemicolon {
-  val x = 3
+  val x = 3;
   println(x)
 
   val a = 1; val b = 2

--- a/output/src/main/scala/fix/UnnecessarySemicolon.scala
+++ b/output/src/main/scala/fix/UnnecessarySemicolon.scala
@@ -1,0 +1,8 @@
+package fix
+
+object UnnecessarySemicolon {
+  val x = 3
+  println(x)
+
+  val a = 1; val b = 2
+}

--- a/output/src/main/scala/fix/pixiv/UnnecessarySemicolon.scala
+++ b/output/src/main/scala/fix/pixiv/UnnecessarySemicolon.scala
@@ -1,11 +1,8 @@
-/*
-rule = UnnecessarySemicolon
-*/
-package fix
+package fix.pixiv
 
 object UnnecessarySemicolon {
-  val x = 3;
+  val x = 3
   println(x)
 
   val a = 1; val b = 2
-};
+}

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,10 @@
 # Scalafix rules for Scalafix-Rule-Pixiv
 
-To develop rule:
-```
-sbt ~tests/test
-# edit rules/src/main/scala/fix/〇〇.scala
+## fix.pixiv.UnnecessarySemicolon
+
+不要な行末セミコロンを削除します。セミコロン後に行が接続されている場合には削除しません。
+
+```scala
+val x = 3; // rewrite to: `val x = 3`
+val a = 1; val b = 2
 ```

--- a/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,1 +1,1 @@
-fix.UnnecessarySemicolon
+fix.pixiv.UnnecessarySemicolon

--- a/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,0 +1,1 @@
+fix.UnnecessarySemicolon

--- a/rules/src/main/scala/fix/UnnecessarySemicolon.scala
+++ b/rules/src/main/scala/fix/UnnecessarySemicolon.scala
@@ -1,0 +1,19 @@
+package fix
+
+import scala.meta.tokens.Token
+
+import scalafix.Patch
+import scalafix.v1.{SyntacticDocument, SyntacticRule}
+
+class UnnecessarySemicolon extends SyntacticRule("UnnecessarySemicolon") {
+
+  override def fix(implicit doc: SyntacticDocument): Patch = {
+    doc.tokens.zipWithIndex.collect {
+      case (semicolon: Token.Semicolon, i) =>
+        doc.tokens(i+1) match {
+          case _@ (Token.CR() | Token.LF() | Token.EOF()) => Patch.replaceToken(semicolon, "")
+          case _ => Patch.empty
+        }
+    }.asPatch
+  }
+}

--- a/rules/src/main/scala/fix/pixiv/UnnecessarySemicolon.scala
+++ b/rules/src/main/scala/fix/pixiv/UnnecessarySemicolon.scala
@@ -1,4 +1,4 @@
-package fix
+package fix.pixiv
 
 import scala.meta.tokens.Token
 
@@ -8,12 +8,12 @@ import scalafix.v1.{SyntacticDocument, SyntacticRule}
 class UnnecessarySemicolon extends SyntacticRule("UnnecessarySemicolon") {
 
   override def fix(implicit doc: SyntacticDocument): Patch = {
-    doc.tokens.zipWithIndex.collect {
-      case (semicolon: Token.Semicolon, i) =>
-        doc.tokens(i+1) match {
-          case _@ (Token.CR() | Token.LF() | Token.EOF()) => Patch.replaceToken(semicolon, "")
-          case _ => Patch.empty
-        }
+    doc.tokens.zipWithIndex.collect { case (semicolon: Token.Semicolon, i) =>
+      doc.tokens(i + 1) match {
+        case _ @(Token.CR() | Token.LF() | Token.EOF()) =>
+          Patch.replaceToken(semicolon, "")
+        case _ => Patch.empty
+      }
     }.asPatch
   }
 }


### PR DESCRIPTION
リポジトリ内の不要セミコロンを削除します。
不要セミコロンは、 `;\n`, `;\r`, `;{EOF}` という形式になっているものとしました。