### PR TITLE
単純化できる空チェック (`.size == 0`) を `isEmpty` に置換する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 on:
   push:
+    branches:
+      - master
   pull_request:
 jobs:
   checks:

--- a/input/src/main/scala/fix/pixiv/CheckIsEmpty.scala
+++ b/input/src/main/scala/fix/pixiv/CheckIsEmpty.scala
@@ -1,0 +1,42 @@
+/*
+rule = CheckIsEmpty
+ */
+package fix.pixiv
+
+object CheckIsEmpty {
+  private val seq = Seq(1, 2, 3)
+  private val option = Some(1)
+
+  // to isEmpty
+  Seq(1, 2, 3).size == 0
+  seq.size == 0
+  seq.length == 0
+  !seq.nonEmpty
+
+  // to nonEmpty
+  seq.size != 0
+  seq.size > 0
+  seq.size >= 1
+  seq.length != 0
+  seq.length > 0
+  seq.length >= 1
+  seq.exists(_ => true)
+  seq.exists(Function.const(true))
+  seq.size != 0
+  seq.length != 0
+  !seq.isEmpty
+
+  // to isEmpty
+  option.size == 0
+  option == None
+  None == option
+  !option.isDefined
+
+  // to isDefined
+  option != None
+  None != option
+  option.nonEmpty
+
+  // 配列には isEmpty が存在しないので無視する
+  Array(1, 2, 3).length == 0
+}

--- a/input/src/main/scala/fix/pixiv/CheckIsEmpty.scala
+++ b/input/src/main/scala/fix/pixiv/CheckIsEmpty.scala
@@ -1,5 +1,6 @@
 /*
 rule = CheckIsEmpty
+CheckIsEmpty.alignIsDefined = true
  */
 package fix.pixiv
 

--- a/input/src/main/scala/fix/pixiv/CheckIsEmpty.scala
+++ b/input/src/main/scala/fix/pixiv/CheckIsEmpty.scala
@@ -40,4 +40,11 @@ object CheckIsEmpty {
 
   // 配列には isEmpty が存在しないので無視する
   Array(1, 2, 3).length == 0
+
+  case class InSeq(seq: Seq[Int]) {
+    def getSeq(i: Int): Seq[Int] = seq.slice(0, i)
+  }
+  private val inSeq = InSeq(Seq(1, 2, 3))
+  inSeq.seq.size == 0
+  inSeq.getSeq(2).size == 0
 }

--- a/output/src/main/scala/fix/pixiv/CheckIsEmpty.scala
+++ b/output/src/main/scala/fix/pixiv/CheckIsEmpty.scala
@@ -1,6 +1,3 @@
-/*
-rule = CheckIsEmpty
- */
 package fix.pixiv
 
 object CheckIsEmpty {

--- a/output/src/main/scala/fix/pixiv/CheckIsEmpty.scala
+++ b/output/src/main/scala/fix/pixiv/CheckIsEmpty.scala
@@ -36,4 +36,11 @@ object CheckIsEmpty {
 
   // 配列には isEmpty が存在しないので無視する
   Array(1, 2, 3).length == 0
+
+  case class InSeq(seq: Seq[Int]) {
+    def getSeq(i: Int): Seq[Int] = seq.slice(0, i)
+  }
+  private val inSeq = InSeq(Seq(1, 2, 3))
+  inSeq.seq.isEmpty
+  inSeq.getSeq(2).isEmpty
 }

--- a/output/src/main/scala/fix/pixiv/CheckIsEmpty.scala
+++ b/output/src/main/scala/fix/pixiv/CheckIsEmpty.scala
@@ -1,0 +1,42 @@
+/*
+rule = CheckIsEmpty
+ */
+package fix.pixiv
+
+object CheckIsEmpty {
+  private val seq = Seq(1, 2, 3)
+  private val option = Some(1)
+
+  // to isEmpty
+  Seq(1, 2, 3).isEmpty
+  seq.isEmpty
+  seq.isEmpty
+  seq.isEmpty
+
+  // to nonEmpty
+  seq.nonEmpty
+  seq.nonEmpty
+  seq.nonEmpty
+  seq.nonEmpty
+  seq.nonEmpty
+  seq.nonEmpty
+  seq.nonEmpty
+  seq.nonEmpty
+  seq.nonEmpty
+  seq.nonEmpty
+  seq.nonEmpty
+
+  // to isEmpty
+  option.isEmpty
+  option.isEmpty
+  option.isEmpty
+  option.isEmpty
+
+  // to isDefined
+  option.isDefined
+  option.isDefined
+  option.isDefined
+
+  // 配列には isEmpty が存在しないので無視する
+  Array(1, 2, 3).length == 0
+}

--- a/readme.md
+++ b/readme.md
@@ -26,3 +26,13 @@ val a = 1; val b = 2
 /* rule = ZeroIndexToHead */
 Seq(1, 2, 3)(0) // rewrite to: `Seq(1, 2, 3).head`
 ```
+
+## fix.pixiv.CheckIsEmpty
+
+`Option` や `Seq` の空チェックに `isEmpty`, `nonEmpty`, `isDefined` を利用するように置き換えます。
+
+```scala
+/* rule = CheckIsEmpty */
+Some(1) == None // rewrite to: Some(1).isEmpty
+Some(1).nonEmpty // if `CheckIsEmpty.alignIsDefined = true` then rewrite to Some(1).isDefined
+```

--- a/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,2 +1,3 @@
 fix.pixiv.UnnecessarySemicolon
 fix.pixiv.ZeroIndexToHead
+fix.pixiv.CheckIsEmpty

--- a/rules/src/main/scala/fix/pixiv/CheckIsEmpty.scala
+++ b/rules/src/main/scala/fix/pixiv/CheckIsEmpty.scala
@@ -2,24 +2,35 @@ package fix.pixiv
 
 import scala.collection.compat.IterableOnce
 import scala.meta.{Lit, Term, Tree}
+
+import fix.pixiv.CheckIsEmpty.isType
 import scalafix.v1.{Patch, SemanticDocument, SemanticRule, XtensionTreeScalafix}
 import util.SymbolConverter.SymbolToSemanticType
 
 class CheckIsEmpty extends SemanticRule("CheckIsEmpty") {
   override def fix(implicit doc: SemanticDocument): Patch = {
     doc.tree.collect {
-      case t @ IsDefined(x1, rewrite) if rewrite && x1.symbol.isAssignableTo(classOf[Option[Any]]) =>
+      case t @ IsDefined(x1, rewrite) if rewrite && isType(x1, classOf[Option[Any]]) =>
         Patch.replaceTree(t, Term.Select(x1, Term.Name("isDefined")).toString())
-      case t @ NonEmpty(x1, rewrite) if rewrite && isTypeHasIsEmpty(x1) =>
+      case t @ NonEmpty(x1, rewrite) if rewrite && CheckIsEmpty.isTypeHasIsEmpty(x1) =>
         Patch.replaceTree(t, Term.Select(x1, Term.Name("nonEmpty")).toString())
-      case t @ IsEmpty(x1, rewrite) if rewrite && isTypeHasIsEmpty(x1) =>
+      case t @ IsEmpty(x1, rewrite) if rewrite && CheckIsEmpty.isTypeHasIsEmpty(x1) =>
         Patch.replaceTree(t, Term.Select(x1, Term.Name("isEmpty")).toString())
     }.asPatch
   }
+}
 
-  private def isTypeHasIsEmpty(x1: Term)(implicit doc: SemanticDocument): Boolean = {
-    x1.symbol.isAssignableTo(classOf[IterableOnce[Any]]) ||
-    x1.symbol.isAssignableTo(classOf[Option[Any]])
+private object CheckIsEmpty {
+  def isTypeHasIsEmpty(x1: Term)(implicit doc: SemanticDocument): Boolean = {
+    isType(x1, classOf[IterableOnce[Any]]) || isType(x1, classOf[Option[Any]])
+  }
+
+  def isType(x1: Term, clazz: Class[_])(implicit doc: SemanticDocument): Boolean = {
+    x1 match {
+      case x1: Term.Name => x1.symbol.isAssignableTo(clazz)
+      case x1 @ Term.Apply(_: Term.Name, _) => x1.symbol.isAssignableTo(clazz)
+      case _ => false
+    }
   }
 }
 
@@ -38,10 +49,10 @@ private object IsEmpty {
     case _ @Term.ApplyUnary(Term.Name("!"), IsDefined(x1, _)) => Some((x1, true))
     // option == None
     case _ @Term.ApplyInfix(x1: Term, _ @Term.Name("=="), Nil, List(Term.Name("None")))
-        if x1.symbol.isAssignableTo(classOf[Option[Any]]) => Some((x1, true))
+        if isType(x1, classOf[Option[Any]]) => Some((x1, true))
     // None == option
     case _ @Term.ApplyInfix(Term.Name("None"), _ @Term.Name("=="), Nil, List(x1: Term))
-        if x1.symbol.isAssignableTo(classOf[Option[Any]]) => Some((x1, true))
+        if isType(x1, classOf[Option[Any]]) => Some((x1, true))
     case _ => None
   }
 }
@@ -74,7 +85,7 @@ private object NonEmpty {
           Term.Select(x1, _ @Term.Name("exists")),
           List(Term.Apply(Term.Select(Term.Name("Function"), Term.Name("const")), List(Lit.Boolean(true))))
         ) => Some((x1, true))
-    case _ @Term.ApplyUnary(Term.Name("!"), IsEmpty(x1, _)) if !x1.symbol.isAssignableTo(classOf[Option[Any]]) =>
+    case _ @Term.ApplyUnary(Term.Name("!"), IsEmpty(x1, _)) if !isType(x1, classOf[Option[Any]]) =>
       Some((x1, true))
     case _ => None
   }
@@ -88,8 +99,11 @@ private object IsDefined {
     case _ @Term.ApplyInfix(x1: Term, _ @Term.Name("!="), Nil, List(Term.Name("None"))) => Some((x1, true))
     // None != option
     case _ @Term.ApplyInfix(Term.Name("None"), _ @Term.Name("!="), Nil, List(x1: Term)) => Some((x1, true))
+    case _ @NonEmpty(Term.Placeholder(), _) => None
+    case _ @Term.ApplyUnary(Term.Name("!"), IsEmpty(x1, _)) if isType(x1, classOf[Option[Any]]) =>
+      Some((x1, true))
     // option.nonEmpty => option.isDefined
-    case _ @NonEmpty(x1, _) if x1.symbol.isAssignableTo(classOf[Option[Any]]) => Some((x1, true))
+    case _ @NonEmpty(x1, _) if isType(x1, classOf[Option[Any]]) => Some((x1, true))
     case _ => None
   }
 }

--- a/rules/src/main/scala/fix/pixiv/CheckIsEmpty.scala
+++ b/rules/src/main/scala/fix/pixiv/CheckIsEmpty.scala
@@ -7,6 +7,7 @@ import fix.pixiv.CheckIsEmpty.isType
 import metaconfig.Configured
 import scalafix.v1.{Configuration, Patch, Rule, SemanticDocument, SemanticRule, XtensionTreeScalafix}
 import util.SymbolConverter.SymbolToSemanticType
+import util.ToClassException
 
 class CheckIsEmpty(config: CheckIsEmptyConfig) extends SemanticRule("CheckIsEmpty") {
   def this() = this(CheckIsEmptyConfig.default)
@@ -34,12 +35,17 @@ private object CheckIsEmpty {
   }
 
   def isType(x1: Term, clazz: Class[_])(implicit doc: SemanticDocument): Boolean = {
-    x1 match {
-      case x1: Term.Name => x1.symbol.isAssignableTo(clazz)
-      case x1 @ Term.Apply(_: Term.Name, _) => x1.symbol.isAssignableTo(clazz)
-      case _ @Term.Select(_, x1: Term.Name) => x1.symbol.isAssignableTo(clazz)
-      case _ @Term.Apply(_ @Term.Select(_, x1: Term.Name), _) => x1.symbol.isAssignableTo(clazz)
-      case _ => false
+    try {
+      x1 match {
+        case x1: Term.Name => x1.symbol.isAssignableTo(clazz)
+        case x1 @ Term.Apply(_: Term.Name, _) => x1.symbol.isAssignableTo(clazz)
+        case _ @Term.Select(_, x1: Term.Name) => x1.symbol.isAssignableTo(clazz)
+        case _ @Term.Apply(_ @Term.Select(_, x1: Term.Name), _) => x1.symbol.isAssignableTo(clazz)
+        case _ => false
+      }
+    } catch {
+      // 結果が型アノテーションだと現状検査できないのでスルーする
+      case _: ToClassException => false
     }
   }
 }

--- a/rules/src/main/scala/fix/pixiv/CheckIsEmpty.scala
+++ b/rules/src/main/scala/fix/pixiv/CheckIsEmpty.scala
@@ -7,7 +7,6 @@ import fix.pixiv.CheckIsEmpty.isType
 import metaconfig.Configured
 import scalafix.v1.{Configuration, Patch, Rule, SemanticDocument, SemanticRule, XtensionTreeScalafix}
 import util.SymbolConverter.SymbolToSemanticType
-import util.ToClassException
 
 class CheckIsEmpty(config: CheckIsEmptyConfig) extends SemanticRule("CheckIsEmpty") {
   def this() = this(CheckIsEmptyConfig.default)
@@ -44,8 +43,7 @@ private object CheckIsEmpty {
         case _ => false
       }
     } catch {
-      // 結果が型アノテーションだと現状検査できないのでスルーする
-      case _: ToClassException => false
+      case _: Throwable => false
     }
   }
 }

--- a/rules/src/main/scala/fix/pixiv/CheckIsEmpty.scala
+++ b/rules/src/main/scala/fix/pixiv/CheckIsEmpty.scala
@@ -2,6 +2,7 @@ package fix.pixiv
 
 import scala.collection.compat.IterableOnce
 import scala.meta.{Lit, Term, Tree}
+
 import fix.pixiv.CheckIsEmpty.isType
 import metaconfig.Configured
 import scalafix.v1.{Configuration, Patch, Rule, SemanticDocument, SemanticRule, XtensionTreeScalafix}
@@ -36,6 +37,8 @@ private object CheckIsEmpty {
     x1 match {
       case x1: Term.Name => x1.symbol.isAssignableTo(clazz)
       case x1 @ Term.Apply(_: Term.Name, _) => x1.symbol.isAssignableTo(clazz)
+      case _ @Term.Select(_, x1: Term.Name) => x1.symbol.isAssignableTo(clazz)
+      case _ @Term.Apply(_ @Term.Select(_, x1: Term.Name), _) => x1.symbol.isAssignableTo(clazz)
       case _ => false
     }
   }

--- a/rules/src/main/scala/fix/pixiv/CheckIsEmpty.scala
+++ b/rules/src/main/scala/fix/pixiv/CheckIsEmpty.scala
@@ -1,0 +1,95 @@
+package fix.pixiv
+
+import scala.collection.compat.IterableOnce
+import scala.meta.{Lit, Term, Tree}
+import scalafix.v1.{Patch, SemanticDocument, SemanticRule, XtensionTreeScalafix}
+import util.SymbolConverter.SymbolToSemanticType
+
+class CheckIsEmpty extends SemanticRule("CheckIsEmpty") {
+  override def fix(implicit doc: SemanticDocument): Patch = {
+    doc.tree.collect {
+      case t @ IsDefined(x1, rewrite) if rewrite && x1.symbol.isAssignableTo(classOf[Option[Any]]) =>
+        Patch.replaceTree(t, Term.Select(x1, Term.Name("isDefined")).toString())
+      case t @ NonEmpty(x1, rewrite) if rewrite && isTypeHasIsEmpty(x1) =>
+        Patch.replaceTree(t, Term.Select(x1, Term.Name("nonEmpty")).toString())
+      case t @ IsEmpty(x1, rewrite) if rewrite && isTypeHasIsEmpty(x1) =>
+        Patch.replaceTree(t, Term.Select(x1, Term.Name("isEmpty")).toString())
+    }.asPatch
+  }
+
+  private def isTypeHasIsEmpty(x1: Term)(implicit doc: SemanticDocument): Boolean = {
+    x1.symbol.isAssignableTo(classOf[IterableOnce[Any]]) ||
+    x1.symbol.isAssignableTo(classOf[Option[Any]])
+  }
+}
+
+private object IsEmpty {
+  def unapply(tree: Tree)(implicit doc: SemanticDocument): Option[(Term, Boolean)] = tree match {
+    // `seq.isEmpty` は変換不要だが IsEmpty ではある
+    case _ @Term.Select(x1: Term, _ @Term.Name("isEmpty")) => Some(x1, false)
+    // `seq.size == 0`
+    case _ @Term.ApplyInfix(
+          Term.Select(x1: Term, _ @(Term.Name("size") | Term.Name("length"))),
+          Term.Name("=="),
+          Nil,
+          List(Lit.Int(0))
+        ) => Some((x1, true))
+    case _ @Term.ApplyUnary(Term.Name("!"), NonEmpty(x1, _)) => Some((x1, true))
+    case _ @Term.ApplyUnary(Term.Name("!"), IsDefined(x1, _)) => Some((x1, true))
+    // option == None
+    case _ @Term.ApplyInfix(x1: Term, _ @Term.Name("=="), Nil, List(Term.Name("None")))
+        if x1.symbol.isAssignableTo(classOf[Option[Any]]) => Some((x1, true))
+    // None == option
+    case _ @Term.ApplyInfix(Term.Name("None"), _ @Term.Name("=="), Nil, List(x1: Term))
+        if x1.symbol.isAssignableTo(classOf[Option[Any]]) => Some((x1, true))
+    case _ => None
+  }
+}
+
+private object NonEmpty {
+  def unapply(tree: Tree)(implicit doc: SemanticDocument): Option[(Term, Boolean)] = tree match {
+    // `seq.nonEmpty` は変換不要だが NonEmpty ではある
+    case _ @Term.Select(x1: Term, _ @Term.Name("nonEmpty")) => Some(x1, false)
+    // `seq.size != 0` or `seq.size > 0`
+    case _ @Term.ApplyInfix(
+          Term.Select(x1: Term, _ @(Term.Name("size") | Term.Name("length"))),
+          _ @(Term.Name("!=") | Term.Name(">")),
+          Nil,
+          List(Lit.Int(0))
+        ) => Some((x1, true))
+    // `seq.size > 1`
+    case _ @Term.ApplyInfix(
+          Term.Select(x1: Term, _ @(Term.Name("size") | Term.Name("length"))),
+          _ @Term.Name(">="),
+          Nil,
+          List(Lit.Int(1))
+        ) => Some((x1, true))
+    // `seq.exists(_ => true)`
+    case _ @Term.Apply(
+          Term.Select(x1, _ @Term.Name("exists")),
+          List(Term.Function((_, Lit.Boolean(true))))
+        ) => Some((x1, true))
+    // `seq.exists(Function.const(true))`
+    case _ @Term.Apply(
+          Term.Select(x1, _ @Term.Name("exists")),
+          List(Term.Apply(Term.Select(Term.Name("Function"), Term.Name("const")), List(Lit.Boolean(true))))
+        ) => Some((x1, true))
+    case _ @Term.ApplyUnary(Term.Name("!"), IsEmpty(x1, _)) if !x1.symbol.isAssignableTo(classOf[Option[Any]]) =>
+      Some((x1, true))
+    case _ => None
+  }
+}
+
+private object IsDefined {
+  def unapply(tree: Tree)(implicit doc: SemanticDocument): Option[(Term, Boolean)] = tree match {
+    // `option.isDefined` は変換不要だが IsDefined ではある
+    case _ @Term.Select(x1: Term, _ @Term.Name("isDefined")) => Some(x1, false)
+    // option != None
+    case _ @Term.ApplyInfix(x1: Term, _ @Term.Name("!="), Nil, List(Term.Name("None"))) => Some((x1, true))
+    // None != option
+    case _ @Term.ApplyInfix(Term.Name("None"), _ @Term.Name("!="), Nil, List(x1: Term)) => Some((x1, true))
+    // option.nonEmpty => option.isDefined
+    case _ @NonEmpty(x1, _) if x1.symbol.isAssignableTo(classOf[Option[Any]]) => Some((x1, true))
+    case _ => None
+  }
+}

--- a/rules/src/main/scala/fix/pixiv/CheckIsEmptyConfig.scala
+++ b/rules/src/main/scala/fix/pixiv/CheckIsEmptyConfig.scala
@@ -1,0 +1,12 @@
+package fix.pixiv
+
+import metaconfig.ConfDecoder
+import metaconfig.generic.Surface
+
+final case class CheckIsEmptyConfig(alignIsDefined: Boolean = false)
+
+object CheckIsEmptyConfig {
+  val default: CheckIsEmptyConfig = CheckIsEmptyConfig()
+  implicit val surface: Surface[CheckIsEmptyConfig] = metaconfig.generic.deriveSurface[CheckIsEmptyConfig]
+  implicit val decoder: ConfDecoder[CheckIsEmptyConfig] = metaconfig.generic.deriveDecoder(default)
+}


### PR DESCRIPTION
`seq.size == 0` のようなコレクションに対して要素の存在可否を確認するような典型コードを `isEmpty` の呼び出しに置き換えるルール。

`IteratorOnce` または `Option` に対する呼び出しに適用される。 (`Array` にも `size` などのメソッドはあるものの、置換先がないため適用されない)

[IntelliJ を参考](https://github.com/JetBrains/intellij-scala/blob/idea213.x/scala/scala-impl/src/org/jetbrains/plugins/scala/codeInspection/collections/EmptyCheckInspection.scala)