### PR TITLE
SemanticType を Class[_] に変換できるようにする

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val src = (project in file("rules"))
   .settings(
     libraryDependencies ++= Seq(
       "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion,
-      "org.scalatest" %% "scalatest" % "3.2.9" % "test"
+      "org.scalatest" %% "scalatest" % "3.2.11" % "test"
     ),
     scalacOptions ++= Seq(
       "-deprecation",
@@ -62,7 +62,10 @@ lazy val src = (project in file("rules"))
 lazy val rules = projectMatrix
   .settings(
     moduleName := "scalafix-pixiv-rule",
-    libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion
+    libraryDependencies ++= Seq(
+      "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion,
+      "org.scalatest" %% "scalatest" % "3.2.11" % "test"
+    )
   )
   .defaultAxes(VirtualAxis.jvm)
   .jvmPlatform(rulesCrossVersions)

--- a/rules/src/main/scala/util/SemanticTypeConverter.scala
+++ b/rules/src/main/scala/util/SemanticTypeConverter.scala
@@ -31,12 +31,28 @@ object SemanticTypeConverter {
 
   def symbolToClass(symbol: scalafix.v1.Symbol): Class[_] = {
     val identifierRegStr = "[a-zA-Z$_][a-zA-Z1-9$_]*"
-    val symbolRegStr = s"($identifierRegStr(?:[/.]$identifierRegStr)*)[#.]"
+    val symbolRegStr = s"($identifierRegStr(?:[/.]$identifierRegStr)*)"
+    val finRegStr = "[#.]"
     val typeRegStr = s"\\[$identifierRegStr(?:,$identifierRegStr)*]$$"
-    // クラス名もしくは
-    val typeValMatch = (s"^$symbolRegStr(?:$typeRegStr)?$$").r
+    val typeValMatch = (s"^$symbolRegStr$finRegStr(?:$typeRegStr)?$$").r
+    val funcValMatch = (s"^$symbolRegStr$finRegStr($identifierRegStr)\\(\\)$finRegStr(?:$typeRegStr)?$$").r
     symbol.toString() match {
       case typeValMatch(str1) => symbolStringToClass(str1.replace('/', '.'))
+      case funcValMatch(str1, str2) =>
+        try {
+          val holder = symbolStringToClass(str1.replace('/', '.'))
+          // メソッドの返り値をリフレクションで取得する
+          import scala.reflect.runtime.universe.{TermName, runtimeMirror}
+          val mirror = runtimeMirror(getClass.getClassLoader)
+          mirror.runtimeClass(
+            mirror.classSymbol(holder).info.member(TermName(str2)).asMethod.returnType
+          )
+        } catch {
+          // メソッドかつ戻り値が T の時は型が取得できない
+          // 外側のメソッドあたりから頑張れば取れるかもしれない
+          case e: Throwable =>
+            throw new ToClassException(s"$str1.$str2() を完全修飾クラス名に変換できませんでした: ${e.getMessage}(${e.getClass})")
+        }
       case _ => throw new ToClassException(s"${symbol.toString()} を完全修飾クラス名に変換できませんでした")
     }
   }

--- a/rules/src/main/scala/util/SemanticTypeConverter.scala
+++ b/rules/src/main/scala/util/SemanticTypeConverter.scala
@@ -1,0 +1,76 @@
+package util
+
+import scala.util.Try
+
+import scalafix.v1.{BooleanConstant, ByteConstant, CharConstant, Constant, ConstantType, DoubleConstant, FloatConstant, IntConstant, LongConstant, NullConstant, SemanticType, ShortConstant, SingleType, StringConstant, SuperType, ThisType, TypeRef, UnitConstant}
+
+object SemanticTypeConverter {
+  implicit class SemanticTypeToClass(semanticType: SemanticType) {
+    def toClass: Class[_] = {
+      semanticType match {
+        case TypeRef(_, symbol, _) =>
+          symbolToClass(symbol)
+        case SingleType(_, symbol) =>
+          symbolToClass(symbol)
+        case ConstantType(constant) =>
+          constantToClass(constant)
+        case SuperType(_, symbol) =>
+          symbolToClass(symbol)
+        case ThisType(symbol) =>
+          symbolToClass(symbol)
+        case _ =>
+          throw new ToClassException(s"${semanticType.toClass} の Class[_] への変換は定義されていません。")
+      }
+    }
+
+    def isAssignableFrom(clazz: Class[_]): Boolean = semanticType.toClass.isAssignableFrom(clazz)
+
+    def isAssignableTo(clazz: Class[_]): Boolean = clazz.isAssignableFrom(semanticType.toClass)
+
+  }
+
+  def symbolToClass(symbol: scalafix.v1.Symbol): Class[_] = {
+    val identifierRegStr = "[a-zA-Z$_][a-zA-Z1-9$_]*"
+    val symbolRegStr = s"($identifierRegStr(?:[/.]$identifierRegStr)*)[#.]"
+    val typeRegStr = s"\\[$identifierRegStr(?:,$identifierRegStr)*]$$"
+    // クラス名もしくは
+    val typeValMatch = (s"^$symbolRegStr(?:$typeRegStr)?$$").r
+    symbol.toString() match {
+      case typeValMatch(str1) => symbolStringToClass(str1.replace('/', '.'))
+      case _ => throw new ToClassException(s"${symbol.toString()} を完全修飾クラス名に変換できませんでした")
+    }
+  }
+
+  def symbolStringToClass(str: String): Class[_] = {
+    Try {
+      // 本来はオブジェクトなら '$' をつけるべきだが、`apply` の戻り値は元のクラスのため、そちらに合わせる
+      Class.forName(str)
+    }.recover[Class[_]] {
+      case _ =>
+        // package object 内で type として再代入されている場合には上記の方法では取得できないため、
+        // 一度コンパニオンオブジェクトを取得してからフィールドとして取り出している。
+        val lastDot = str.lastIndexOf('.')
+        val objCls = Class.forName(str.take(lastDot) + "$")
+        import scala.reflect.runtime.universe.{TypeName, runtimeMirror}
+        val mirror = runtimeMirror(getClass.getClassLoader)
+        val clazz: Class[_] = mirror.runtimeClass(mirror.classSymbol(objCls).toType.decl(
+          TypeName(str.drop(lastDot + 1))
+        ).typeSignature.dealias.typeSymbol.asClass)
+        clazz
+    }.get
+  }
+
+  def constantToClass(constant: Constant): Class[_] = constant match {
+    case UnitConstant => classOf[Unit]
+    case BooleanConstant(_) => classOf[Boolean]
+    case ByteConstant(_) => classOf[Byte]
+    case ShortConstant(_) => classOf[Short]
+    case CharConstant(_) => classOf[Char]
+    case IntConstant(_) => classOf[Int]
+    case LongConstant(_) => classOf[Long]
+    case FloatConstant(_) => classOf[Float]
+    case DoubleConstant(_) => classOf[Double]
+    case StringConstant(_) => classOf[String]
+    case NullConstant => classOf[Null]
+  }
+}

--- a/rules/src/main/scala/util/SymbolConverter.scala
+++ b/rules/src/main/scala/util/SymbolConverter.scala
@@ -1,0 +1,37 @@
+package util
+
+import scalafix.v1.{ClassSignature, MethodSignature, SemanticType, Symtab, TypeRef, TypeSignature, ValueSignature}
+import util.SemanticTypeConverter.SemanticTypeToClass
+
+object SymbolConverter {
+  implicit class SymbolToSemanticType(symbol: scalafix.v1.Symbol)(implicit doc: Symtab) {
+    def toSemanticType: SemanticType = symbol.info.fold(
+      throw new ToClassException(s"${symbol.displayName} は info を持ちません。")
+    ) { info =>
+      info.signature match {
+        case MethodSignature(_, _, returnType) =>
+          returnType
+        case ValueSignature(tpe) =>
+          tpe
+        case TypeSignature(_, lowerBound, upperBound) =>
+          if (lowerBound == upperBound) {
+            lowerBound
+          } else {
+            throw new RuntimeException(
+              s"型パラメータ ${symbol.displayName} の型は一意に定まりません。 lower: $lowerBound, upper: $upperBound"
+            )
+          }
+        case ClassSignature(typeParameters, _, _, _) =>
+          TypeRef(scalafix.v1.NoType, symbol, typeParameters.map(info => info.symbol.toSemanticType))
+        case signature =>
+          throw new ToClassException(s"${symbol.displayName} (${signature.getClass}) は型を持ちません")
+      }
+    }
+
+    def isAssignableFrom(clazz: Class[_]): Boolean = symbol.toSemanticType.isAssignableFrom(clazz)
+
+    def isAssignableTo(clazz: Class[_]): Boolean = symbol.toSemanticType.isAssignableTo(clazz)
+
+  }
+
+}

--- a/rules/src/main/scala/util/ToClassException.scala
+++ b/rules/src/main/scala/util/ToClassException.scala
@@ -1,0 +1,3 @@
+package util
+
+class ToClassException(message: String) extends RuntimeException(message)

--- a/rules/src/test/scala/util/SemanticTypeConverterTest.scala
+++ b/rules/src/test/scala/util/SemanticTypeConverterTest.scala
@@ -1,0 +1,46 @@
+package util
+
+import org.scalatest.funsuite.AnyFunSuite
+import scalafix.v1.{SingleType, TypeRef}
+import util.SemanticTypeConverter.SemanticTypeToClass
+import scala.collection.Seq
+
+class SemanticTypeConverterTest extends AnyFunSuite {
+
+  test("SemanticTypeToClass: TypeRef") {
+    assert(
+      classOf[Seq[_]] == TypeRef(null, scalafix.v1.Symbol("scala/collection/Seq#"), null).toClass
+    )
+  }
+
+  test("SemanticTypeToClass: SingleType") {
+    assert(classOf[Seq[_]] == SingleType(null, scalafix.v1.Symbol("scala/collection/Seq#")).toClass)
+  }
+
+  test("isAssignableFrom") {
+    assert(SingleType(null, scalafix.v1.Symbol("scala/collection/Seq#")).isAssignableFrom(classOf[List[_]]))
+  }
+
+  test("isAssignableTo") {
+    assert(SingleType(null, scalafix.v1.Symbol("scala/collection/Seq#")).isAssignableFrom(classOf[Seq[_]]))
+  }
+
+  test("symbolToClass: クラス名を取得できる") {
+    assert(classOf[Seq[_]] == SemanticTypeConverter.symbolToClass(scalafix.v1.Symbol("scala/collection/Seq#")))
+  }
+
+  test("symbolToClass: 型パラメータを持つクラス名を取得できる") {
+    assert(
+      classOf[List[_]] == SemanticTypeConverter.symbolToClass(scalafix.v1.Symbol("scala/collection/immutable/List#[T]"))
+    )
+  }
+
+  test("symbolStringToClass: クラス名を取得できる") {
+    assert(classOf[Seq[_]] == SemanticTypeConverter.symbolStringToClass("scala.collection.Seq"))
+  }
+
+  test("symbolStringToClass: type で再定義された型からも取得できる") {
+    assert(classOf[java.lang.String] == SemanticTypeConverter.symbolStringToClass("scala.Predef.String"))
+  }
+
+}


### PR DESCRIPTION
[Semantic Type](https://scalacenter.github.io/scalafix/docs/developers/semantic-type.html) から `Class[_]` を取得するクラスを作成した。

[Global なシンボル](https://scalameta.org/docs/semanticdb/specification.html#symbol) はクラス名・メソッド名の完全修飾名に対応しているようなので、その文字列を元に型を取得している。

TODO: 戻り値型が型変数になっている場合に対応する