### PR TITLE
case な Exception に警告を出す

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,15 @@ Seq(1, 2, 3)(0) // rewrite to: `Seq(1, 2, 3).head`
 Some(1) == None // rewrite to: Some(1).isEmpty
 Some(1).nonEmpty // if `CheckIsEmpty.alignIsDefined = true` then rewrite to Some(1).isDefined
 ```
+
+## fix.pixiv.NonCaseException
+
+`Exception` を継承した `case class` の定義に警告を発生させます。
+これは、 `case class` として実装することにより、例外の階層化や一意性による恩恵が損なわれるためです。
+
+```
+/* rule = NonCaseException */
+case class NonCaseException(msg: String) extends RuntimeException(msg)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+case class として Exception を継承することは推奨されません: NonCaseException
+```

--- a/input/src/main/scala/fix/pixiv/NonCaseException.scala
+++ b/input/src/main/scala/fix/pixiv/NonCaseException.scala
@@ -1,0 +1,9 @@
+/*
+rule = NonCaseException
+ */
+package fix.pixiv
+
+case class NonCaseException(msg: String) extends RuntimeException(msg) /* assert: NonCaseException
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+case class として Exception を継承することは推奨されません: NonCaseException
+     */

--- a/output/src/main/scala/fix/pixiv/NonCaseException.scala
+++ b/output/src/main/scala/fix/pixiv/NonCaseException.scala
@@ -1,0 +1,3 @@
+package fix.pixiv
+
+case class NonCaseException(msg: String) extends RuntimeException(msg)

--- a/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,3 +1,4 @@
 fix.pixiv.UnnecessarySemicolon
 fix.pixiv.ZeroIndexToHead
 fix.pixiv.CheckIsEmpty
+fix.pixiv.NonCaseException

--- a/rules/src/main/scala/fix/pixiv/NonCaseException.scala
+++ b/rules/src/main/scala/fix/pixiv/NonCaseException.scala
@@ -1,0 +1,23 @@
+package fix.pixiv
+
+import scala.meta.{Defn, Init, Mod, Position, Template}
+
+import scalafix.Patch
+import scalafix.lint.{Diagnostic, LintSeverity}
+import scalafix.v1.{SemanticDocument, SemanticRule, XtensionTreeScalafix}
+import util.SymbolConverter.SymbolToSemanticType
+
+class NonCaseException extends SemanticRule("NonCaseException") {
+
+  override def fix(implicit doc: SemanticDocument): Patch = {
+    doc.tree.collect {
+      case t @ Defn.Class(List(_: Mod.Case), name, _, _, _ @Template(_, List(_ @Init(typ, _, _)), _, _))
+          if typ.symbol.isAssignableTo(classOf[Exception]) =>
+        Patch.lint(NonCaseExceptionWarn(s"case class として Exception を継承することは推奨されません: $name", t.pos))
+    }.asPatch
+  }
+}
+
+case class NonCaseExceptionWarn(override val message: String, position: Position) extends Diagnostic {
+  override def severity: LintSeverity = LintSeverity.Warning
+}


### PR DESCRIPTION
以下のように、 `case class` として例外クラスを実装すると別の階層で生成された例外が同一オブジェクトとして判定されてしまうため、非推奨としたい

```scala
scala> case class HogeException(message: String) extends RuntimeException(message)
defined class HogeException

scala> val e1 = HogeException("error1")
e1: HogeException = HogeException: error1

scala> val e2 = HogeException("error1")
e2: HogeException = HogeException: error1

scala> e1 == e2
res0: Boolean = true
```
