### PR TITLE
sonatype host の設定をオーバーライド

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,9 @@ inThisBuild(
     ),
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
-    scalaVersion := "2.13.7"
+    scalaVersion := "2.13.7",
+    sonatypeCredentialHost := "s01.oss.sonatype.org",
+    sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
   )
 )
 


### PR DESCRIPTION
https://github.com/sbt/sbt-ci-release

> sonatypeアカウントが新しい（2021年2月以降に作成された）場合、sbt-sonatypeプラグインから継承されたデフォルトのサーバーの場所は機能しません。また、公開設定に次のオーバーライドを含める必要があります。
> ```
> sonatypeCredentialHost ：=  " s01.oss.sonatype.org " 
> sonatypeRepository ：=  " https://s01.oss.sonatype.org/service/local "
> ```