### PR TITLE
zeroToIndex で ToClassException の発生を抑止

### DIFF
--- a/input/src/main/scala/fix/pixiv/ZeroIndexToHead.scala
+++ b/input/src/main/scala/fix/pixiv/ZeroIndexToHead.scala
@@ -14,4 +14,6 @@ object ZeroIndexToHead {
 
   val indexed = IndexedSeq(1, 2, 3)
   indexed(0)
+
+  Some(Seq(1, 2, 3)).get(0) // このパターンではまだ型の取得が実装できていないので変換されない
 }

--- a/output/src/main/scala/fix/pixiv/ZeroIndexToHead.scala
+++ b/output/src/main/scala/fix/pixiv/ZeroIndexToHead.scala
@@ -11,4 +11,6 @@ object ZeroIndexToHead {
 
   val indexed = IndexedSeq(1, 2, 3)
   indexed(0)
+
+  Some(Seq(1, 2, 3)).get(0) // このパターンではまだ型の取得が実装できていないので変換されない
 }

--- a/rules/src/main/scala/fix/pixiv/ZeroIndexToHead.scala
+++ b/rules/src/main/scala/fix/pixiv/ZeroIndexToHead.scala
@@ -4,20 +4,25 @@ import scala.meta._
 
 import scalafix.v1._
 import util.SymbolConverter.SymbolToSemanticType
+import util.ToClassException
 
 class ZeroIndexToHead extends SemanticRule("ZeroIndexToHead") {
 
   override def fix(implicit doc: SemanticDocument): Patch = {
     doc.tree.collect {
       case t @ Term.Apply(x1, List(Lit.Int(0))) =>
-        if (x1.symbol.isAssignableTo(classOf[Seq[Any]])
-          && (!x1.symbol.isAssignableTo(classOf[IndexedSeq[Any]]))) {
-          Patch.replaceTree(
-            t,
-            Term.Select(x1, Term.Name("head")).toString
-          )
-        } else {
-          Patch.empty
+        try {
+          if (x1.symbol.isAssignableTo(classOf[Seq[Any]])
+            && (!x1.symbol.isAssignableTo(classOf[IndexedSeq[Any]]))) {
+            Patch.replaceTree(
+              t,
+              Term.Select(x1, Term.Name("head")).toString
+            )
+          } else {
+            Patch.empty
+          }
+        } catch {
+          case _: ToClassException => Patch.empty
         }
     }.asPatch
   }

--- a/rules/src/main/scala/util/SemanticTypeConverter.scala
+++ b/rules/src/main/scala/util/SemanticTypeConverter.scala
@@ -6,6 +6,7 @@ import scalafix.v1.{BooleanConstant, ByteConstant, CharConstant, Constant, Const
 
 object SemanticTypeConverter {
   implicit class SemanticTypeToClass(semanticType: SemanticType) {
+    @throws[ToClassException]
     def toClass: Class[_] = {
       semanticType match {
         case TypeRef(_, symbol, _) =>
@@ -29,6 +30,7 @@ object SemanticTypeConverter {
 
   }
 
+  @throws[ToClassException]
   def symbolToClass(symbol: scalafix.v1.Symbol): Class[_] = {
     val identifierRegStr = "[a-zA-Z$_][a-zA-Z1-9$_]*"
     val symbolRegStr = s"($identifierRegStr(?:[/.]$identifierRegStr)*)"

--- a/rules/src/main/scala/util/SymbolConverter.scala
+++ b/rules/src/main/scala/util/SymbolConverter.scala
@@ -6,7 +6,7 @@ import util.SemanticTypeConverter.SemanticTypeToClass
 object SymbolConverter {
   implicit class SymbolToSemanticType(symbol: scalafix.v1.Symbol)(implicit doc: Symtab) {
     @throws[ToClassException]
-    private def toSemanticType: SemanticType = symbol.info.fold(
+    def toSemanticType: SemanticType = symbol.info.fold(
       throw new ToClassException(s"${symbol.displayName} は info を持ちません。")
     ) { info =>
       info.signature match {


### PR DESCRIPTION
## やったこと
#3 で追加したルールで、型の取得が未実装のパターンにあたってもエラーを表示しないようにした。

## なぜやるのか
シンボル→型の取得は網羅的には当面できなさそうなのでこの対応でいきたい。

```bash
Caused by: util.ToClassException: scala/Option.getOrElse() を完全修飾クラス名に変換できませんでした
  at util.SemanticTypeConverter$.symbolToClass(SemanticTypeConverter.scala:54)
  at util.SemanticTypeConverter$SemanticTypeToClass.toClass(SemanticTypeConverter.scala:12)
  at util.SemanticTypeConverter$SemanticTypeToClass.isAssignableTo(SemanticTypeConverter.scala:28)
  at util.SymbolConverter$SymbolToSemanticType.isAssignableTo(SymbolConverter.scala:33)
  at fix.pixiv.ZeroIndexToHead$$anonfun$fix$1.applyOrElse(ZeroIndexToHead.scala:13)
  at fix.pixiv.ZeroIndexToHead$$anonfun$fix$1.applyOrElse(ZeroIndexToHead.scala:11)
```