### PR TITLE
case Exception のエラーレベルをエラーにする

### DIFF
--- a/rules/src/main/scala/fix/pixiv/NonCaseException.scala
+++ b/rules/src/main/scala/fix/pixiv/NonCaseException.scala
@@ -14,7 +14,7 @@ class NonCaseException extends SemanticRule("NonCaseException") {
       case t @ Defn.Class(List(_: Mod.Case), name, _, _, _ @Template(_, List(_ @Init(typ, _, _)), _, _)) =>
         try {
           if (typ.symbol.isAssignableTo(classOf[Exception])) {
-            Patch.lint(NonCaseExceptionWarn(s"case class として Exception を継承することは推奨されません: $name", t.pos))
+            Patch.lint(NonCaseExceptionError(s"case class として Exception を継承することは推奨されません: $name", t.pos))
           } else {
             Patch.empty
           }
@@ -25,6 +25,6 @@ class NonCaseException extends SemanticRule("NonCaseException") {
   }
 }
 
-case class NonCaseExceptionWarn(override val message: String, position: Position) extends Diagnostic {
-  override def severity: LintSeverity = LintSeverity.Warning
+case class NonCaseExceptionError(override val message: String, position: Position) extends Diagnostic {
+  override def severity: LintSeverity = LintSeverity.Error
 }


### PR DESCRIPTION
close #18 
`NonCaseException` ルールはこれまで警告扱いだったが、CIなどで利用する際にエラーレベルでないと検出できないことが多いため変更する。