### PR TITLE
feat: Scala 2.12 系のサポート

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v13
       - name: scalafix
-        run: sbt "src/scalafix --check"
+        run: sbt "+src/scalafix --check"
       - name: scalafmt
-        run: sbt scalafmtSbtCheck "src/scalafmtCheckAll" "input2_13/scalafmtCheckAll"
+        run: sbt scalafmtSbtCheck "src/scalafmtCheckAll" "input2_13/scalafmtCheckAll" "input2_12/scalafmtCheckAll"
       - name: Test
         run: sbt test

--- a/README-en.md
+++ b/README-en.md
@@ -56,6 +56,8 @@ case class として Exception を継承することは推奨されません: No
 
 ## fix.pixiv.UnifyEmptyList
 
+⚠️ Only Scala 2.13.x is supported
+
 Replace `List()` and `List.empty` without type variables specification with `Nil`.
 
 This is because `Nil` is defined as `List[Nothing]`.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ case class として Exception を継承することは推奨されません: No
 
 ## fix.pixiv.UnifyEmptyList
 
+⚠️ Scala 2.13.x 系のみ対応しています。
+
 型変数指定のない `List()` や `List.empty` を `Nil` に置き換えます。
 これは、 `Nil` が `List[Nothing]` として定義されているためです。
 また、型変数指定のある `List[Any]()` は `List.empty[Any]` へと置換されます。

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.sbt.SbtLicenseReport.autoImportImpl.licenseReportDir
 
 lazy val V = _root_.scalafix.sbt.BuildInfo
 
-lazy val rulesCrossVersions = Seq(V.scala213)
+lazy val rulesCrossVersions = Seq(V.scala213, V.scala212)
 lazy val scala3Version = "3.0.1"
 
 ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value)
@@ -115,6 +115,11 @@ lazy val tests = projectMatrix
   .customRow(
     scalaVersions = Seq(V.scala213),
     axisValues = Seq(TargetAxis(V.scala213), VirtualAxis.jvm),
+    settings = Seq()
+  )
+  .customRow(
+    scalaVersions = Seq(V.scala212),
+    axisValues = Seq(TargetAxis(V.scala212), VirtualAxis.jvm),
     settings = Seq()
   )
   .dependsOn(rules)

--- a/input/src/main/scala-2.13/fix/pixiv/UnifyEmptyList.scala
+++ b/input/src/main/scala-2.13/fix/pixiv/UnifyEmptyList.scala
@@ -9,7 +9,7 @@ object UnifyEmptyList {
   private val nothingList = List[Nothing]()
   private val empty = List.empty
   private val varType: List[String] = List()
-  List(1, 2).foldLeft[List[Int]](List.empty)((l, a) => l.appended(a))
+  List(1, 2).foldLeft[List[Int]](List.empty)((l, a) => l :+ a)
   varType match {
     case List() => 0
     case "1" :: "2" :: Nil => 2
@@ -18,9 +18,9 @@ object UnifyEmptyList {
   private def func(list: List[String] = List()): Unit = {}
   // empty に変換する
   private val listType = List[String]()
-  List(1, 2).foldLeft(List[Int]())((l, a) => l.appended(a))
+  List(1, 2).foldLeft(List[Int]())((l, a) => l :+ a)
   private def typeFunc(list: List[String] = List[String]()): Unit = {}
   // 変換しない
   private val emptyType = List.empty[String]
-  List(1, 2).foldLeft(List.empty[Int])((l, a) => l.appended(a))
+  List(1, 2).foldLeft(List.empty[Int])((l, a) => l :+ a)
 }

--- a/output/src/main/scala-2.13/fix/pixiv/UnifyEmptyList.scala
+++ b/output/src/main/scala-2.13/fix/pixiv/UnifyEmptyList.scala
@@ -6,7 +6,7 @@ object UnifyEmptyList {
   private val nothingList = Nil
   private val empty = Nil
   private val varType: List[String] = Nil
-  List(1, 2).foldLeft[List[Int]](Nil)((l, a) => l.appended(a))
+  List(1, 2).foldLeft[List[Int]](Nil)((l, a) => l :+ a)
   varType match {
     case Nil => 0
     case "1" :: "2" :: Nil => 2
@@ -15,9 +15,9 @@ object UnifyEmptyList {
   private def func(list: List[String] = Nil): Unit = {}
   // empty に変換する
   private val listType = List.empty[String]
-  List(1, 2).foldLeft(List.empty[Int])((l, a) => l.appended(a))
+  List(1, 2).foldLeft(List.empty[Int])((l, a) => l :+ a)
   private def typeFunc(list: List[String] = List.empty[String]): Unit = {}
   // 変換しない
   private val emptyType = List.empty[String]
-  List(1, 2).foldLeft(List.empty[Int])((l, a) => l.appended(a))
+  List(1, 2).foldLeft(List.empty[Int])((l, a) => l :+ a)
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.7.1

--- a/rules/src/main/scala/fix/pixiv/SingleConditionMatch.scala
+++ b/rules/src/main/scala/fix/pixiv/SingleConditionMatch.scala
@@ -65,7 +65,7 @@ class SingleConditionMatch extends SemanticRule("SingleConditionMatch") {
   private def toBlockPatch(from: Tree, defVal: Defn.Val, body: Term): Patch = {
     // Block に変換する際、改行を入れないと前の処理の引数として渡されてしまうことがある
     body match {
-      case Term.Block(list) => Patch.replaceTree(from, "\n" + Term.Block(List(defVal).appendedAll(list)).toString)
+      case Term.Block(list) => Patch.replaceTree(from, "\n" + Term.Block(List(defVal) ++ list).toString)
       case body => Patch.replaceTree(from, "\n" + Term.Block(List(defVal, body)).toString)
     }
   }


### PR DESCRIPTION
close #37 
`UnifyEmptyList` 以外のルールを Scala 2.12 系でも利用できるようにした