### PR TITLE
fix: 高階関数が使われている場合にも変換ができるようにする

### DIFF
--- a/input/src/main/scala-2.13/fix/pixiv/MockitoThenToDo.scala
+++ b/input/src/main/scala-2.13/fix/pixiv/MockitoThenToDo.scala
@@ -11,7 +11,7 @@ class MockitoThenToDo {
     def hoge(): String = "hoge"
     def fuga: String = "fuga"
     def piyo(s: String): String = s"piyo: $s"
-    def foo: String = "foo"
+    def foo(a: Int)(b: Int): String = "foo"
   }
   private val a = Mockito.mock(classOf[A])
   Mockito.when(a.hoge()).thenReturn("mock1").thenReturn("mock2")
@@ -20,9 +20,9 @@ class MockitoThenToDo {
     val s = invocation.getArgument[String](0)
     s"mock: $s"
   }
-  Mockito.when(a.foo).thenThrow(new RuntimeException("mock"))
+  Mockito.when(a.foo(1)(2)).thenThrow(new RuntimeException("mock"))
   println(a.hoge())
   println(a.fuga)
   println(a.piyo(""))
-  println(a.foo)
+  println(a.foo(1)(2))
 }

--- a/input/src/main/scala-2.13/fix/pixiv/MockitoThenToDo.scala
+++ b/input/src/main/scala-2.13/fix/pixiv/MockitoThenToDo.scala
@@ -15,7 +15,7 @@ class MockitoThenToDo {
   }
   private val a = Mockito.mock(classOf[A])
   Mockito.when(a.hoge()).thenReturn("mock1").thenReturn("mock2")
-  when(a.fuga).thenReturn("mock")
+  when(a.fuga).thenReturn("mock1", "mock2")
   Mockito.when(a.piyo(ArgumentMatchers.any())).thenAnswer { invocation =>
     val s = invocation.getArgument[String](0)
     s"mock: $s"

--- a/output/src/main/scala-2.13/fix/pixiv/MockitoThenToDo.scala
+++ b/output/src/main/scala-2.13/fix/pixiv/MockitoThenToDo.scala
@@ -8,7 +8,7 @@ class MockitoThenToDo {
     def hoge(): String = "hoge"
     def fuga: String = "fuga"
     def piyo(s: String): String = s"piyo: $s"
-    def foo: String = "foo"
+    def foo(a: Int)(b: Int): String = "foo"
   }
   private val a = Mockito.mock(classOf[A])
   Mockito.doReturn("mock1").doReturn("mock2").when(a).hoge()
@@ -17,9 +17,9 @@ class MockitoThenToDo {
   val s = invocation.getArgument[String](0)
   s"mock: $s"
 }.when(a).piyo(ArgumentMatchers.any())
-  Mockito.doThrow(new RuntimeException("mock")).when(a).foo
+  Mockito.doThrow(new RuntimeException("mock")).when(a).foo(1)(2)
   println(a.hoge())
   println(a.fuga)
   println(a.piyo(""))
-  println(a.foo)
+  println(a.foo(1)(2))
 }

--- a/output/src/main/scala-2.13/fix/pixiv/MockitoThenToDo.scala
+++ b/output/src/main/scala-2.13/fix/pixiv/MockitoThenToDo.scala
@@ -12,7 +12,7 @@ class MockitoThenToDo {
   }
   private val a = Mockito.mock(classOf[A])
   Mockito.doReturn("mock1").doReturn("mock2").when(a).hoge()
-  Mockito.doReturn("mock").when(a).fuga
+  Mockito.doReturn("mock1", "mock2").when(a).fuga
   Mockito.doAnswer { invocation => 
   val s = invocation.getArgument[String](0)
   s"mock: $s"

--- a/rules/src/main/scala/fix/pixiv/MockitoThenToDo.scala
+++ b/rules/src/main/scala/fix/pixiv/MockitoThenToDo.scala
@@ -25,7 +25,7 @@ private object MockitoDo {
       case method => throw new RuntimeException(s"Mockito の then メソッドでない可能性があります: $method")
     }
 
-  def apply(target: Term.Name, func: Term.Name, args: List[List[Term]], thenTerm: List[(String, Term)]): Term = {
+  def apply(target: Term.Name, func: Term.Name, args: List[List[Term]], thenTerm: List[(String, List[Term])]): Term = {
     val doTherm = thenTerm.foldLeft[Term] {
       Term.Name("Mockito")
     } { case (term, (method, result)) =>
@@ -34,7 +34,7 @@ private object MockitoDo {
           term,
           Term.Name(mathodNameConverter(method))
         ),
-        List(result)
+        result
       )
     }
     args match {
@@ -71,13 +71,13 @@ private object MockitoDo {
 private object MockitoThen {
   val methodNames: List[String] =
     List("thenReturn", "thenAnswer", "thenThrow")
-  def unapply(tree: Tree): Option[(Term.Name, Term.Name, List[List[Term]], List[(String, Term)])] = tree match {
+  def unapply(tree: Tree): Option[(Term.Name, Term.Name, List[List[Term]], List[(String, List[Term])])] = tree match {
     case Term.Apply(
           Term.Select(
-            MockitoThen(target, func, args, thenTerm: List[(String, Term)]),
+            MockitoThen(target, func, args, thenTerm: List[(String, List[Term])]),
             Term.Name(method)
           ),
-          List(result)
+          result
         ) if methodNames.contains(method) =>
       Some(target, func, args, thenTerm :+ (method, result))
     case Term.Apply(

--- a/rules/src/main/scala/fix/pixiv/MockitoThenToDo.scala
+++ b/rules/src/main/scala/fix/pixiv/MockitoThenToDo.scala
@@ -25,7 +25,7 @@ private object MockitoDo {
       case method => throw new RuntimeException(s"Mockito の then メソッドでない可能性があります: $method")
     }
 
-  def apply(target: Term.Name, func: Term.Name, args: Option[List[Term]], thenTerm: List[(String, Term)]): Term = {
+  def apply(target: Term.Name, func: Term.Name, args: List[List[Term]], thenTerm: List[(String, Term)]): Term = {
     val doTherm = thenTerm.foldLeft[Term] {
       Term.Name("Mockito")
     } { case (term, (method, result)) =>
@@ -38,21 +38,7 @@ private object MockitoDo {
       )
     }
     args match {
-      case Some(args) =>
-        Term.Apply(
-          Term.Select(
-            Term.Apply(
-              Term.Select(
-                doTherm,
-                Term.Name("when")
-              ),
-              List(func)
-            ),
-            target
-          ),
-          args
-        )
-      case None =>
+      case Nil =>
         Term.Select(
           Term.Apply(
             Term.Select(
@@ -63,6 +49,21 @@ private object MockitoDo {
           ),
           target
         )
+      case list: List[List[Term]] =>
+        list.foldLeft[Term](
+          Term.Select(
+            Term.Apply(
+              Term.Select(
+                doTherm,
+                Term.Name("when")
+              ),
+              List(func)
+            ),
+            target
+          )
+        ) {
+          case (select, arg) => Term.Apply(select, arg)
+        }
     }
   }
 }
@@ -70,43 +71,32 @@ private object MockitoDo {
 private object MockitoThen {
   val methodNames: List[String] =
     List("thenReturn", "thenAnswer", "thenThrow")
-  def unapply(tree: Tree): Option[(Term.Name, Term.Name, Option[List[Term]], List[(String, Term)])] = tree match {
+  def unapply(tree: Tree): Option[(Term.Name, Term.Name, List[List[Term]], List[(String, Term)])] = tree match {
     case Term.Apply(
           Term.Select(
-            MockitoThenInternal(target, func, args, thenTerm: List[(String, Term)]),
+            MockitoThen(target, func, args, thenTerm: List[(String, Term)]),
             Term.Name(method)
           ),
           List(result)
-        ) if methodNames.contains(method) => Some(target, func, args, thenTerm :+ (method, result))
+        ) if methodNames.contains(method) =>
+      Some(target, func, args, thenTerm :+ (method, result))
+    case Term.Apply(
+          (Term.Select(
+            Term.Name("Mockito"),
+            Term.Name("when")
+          ) | Term.Name("when")),
+          List(MockitoThenInternal(target, func, args))
+        ) => Some(target, func, args, Nil)
     case _ => None
   }
 
   private object MockitoThenInternal {
-    def unapply(tree: Tree): Option[(Term.Name, Term.Name, Option[List[Term]], List[(String, Term)])] = tree match {
+    def unapply(tree: Tree): Option[(Term.Name, Term.Name, List[List[Term]])] = tree match {
       case Term.Apply(
-            Term.Select(
-              MockitoThenInternal(target, func, args, thenTerm: List[(String, Term)]),
-              Term.Name(method)
-            ),
-            List(result)
-          ) if methodNames.contains(method) =>
-        Some(target, func, args, thenTerm :+ (method, result))
-      case Term.Apply(
-            (Term.Select(
-              Term.Name("Mockito"),
-              Term.Name("when")
-            ) | Term.Name("when")),
-            List(Term.Apply(Term.Select(func: Term.Name, target), args))
-          ) => Some(target, func, Some(args), Nil)
-      case Term.Apply(
-            (Term.Select(
-              Term.Name("Mockito"),
-              Term.Name("when")
-            ) | Term.Name("when")),
-            List(Term.Select(func: Term.Name, target))
-          ) => Some(target, func, None, Nil)
-      case _ => None
+            MockitoThenInternal(target, func, args),
+            arg
+          ) => Some(target, func, args :+ arg)
+      case Term.Select(func: Term.Name, target) => Some(target, func, Nil)
     }
   }
-
 }


### PR DESCRIPTION
```scala
def foo(a: Int)(b: Int): String = "foo"

// before
Mockito.when(a.foo(1)(2)).thenThrow(new RuntimeException("mock"))

// after
Mockito.doThrow(new RuntimeException("mock")).when(a).foo(1)(2)