### PR TITLE
fix: ZeroIndexToHead で Seq(0) のオブジェクト生成が head になる問題を修正

### DIFF
--- a/input/src/main/scala/fix/pixiv/ZeroIndexToHead.scala
+++ b/input/src/main/scala/fix/pixiv/ZeroIndexToHead.scala
@@ -7,6 +7,8 @@ object ZeroIndexToHead {
   val seq = Seq(1, 2, 3)
   seq(0)
 
+  Seq(0) // これは apply 相当のため .head に変換されない
+
   Seq(1, 2, 3)(0)
 
   val list = List(1, 2, 3)

--- a/output/src/main/scala/fix/pixiv/ZeroIndexToHead.scala
+++ b/output/src/main/scala/fix/pixiv/ZeroIndexToHead.scala
@@ -4,6 +4,8 @@ object ZeroIndexToHead {
   val seq = Seq(1, 2, 3)
   seq.head
 
+  Seq(0) // これは apply 相当のため .head に変換されない
+
   Seq(1, 2, 3).head
 
   val list = List(1, 2, 3)

--- a/rules/src/main/scala/fix/pixiv/CheckIsEmpty.scala
+++ b/rules/src/main/scala/fix/pixiv/CheckIsEmpty.scala
@@ -1,6 +1,7 @@
 package fix.pixiv
 
-import scala.collection.compat.IterableOnce
+import scala.collection.immutable.{NumericRange, Queue}
+import scala.collection.mutable
 import scala.meta.{Lit, Term, Tree}
 
 import fix.pixiv.CheckIsEmpty.isType
@@ -30,7 +31,23 @@ class CheckIsEmpty(config: CheckIsEmptyConfig) extends SemanticRule("CheckIsEmpt
 
 private object CheckIsEmpty {
   def isTypeHasIsEmpty(x1: Term)(implicit doc: SemanticDocument): Boolean = {
-    isType(x1, classOf[IterableOnce[Any]]) || isType(x1, classOf[Option[Any]])
+    Seq(
+      classOf[Seq[Any]],
+      Seq.getClass,
+      Vector.getClass,
+      NumericRange.getClass,
+      // String はこのルールでは扱わない
+      Range.getClass,
+      List.getClass,
+      Queue.getClass,
+      classOf[mutable.Seq[Any]],
+      classOf[Option[Any]],
+      Option.getClass,
+      Some.getClass,
+      None.getClass
+    ).exists { clazz =>
+      isType(x1, clazz)
+    }
   }
 
   def isType(x1: Term, clazz: Class[_])(implicit doc: SemanticDocument): Boolean = {

--- a/rules/src/main/scala/fix/pixiv/ZeroIndexToHead.scala
+++ b/rules/src/main/scala/fix/pixiv/ZeroIndexToHead.scala
@@ -9,6 +9,20 @@ class ZeroIndexToHead extends SemanticRule("ZeroIndexToHead") {
 
   override def fix(implicit doc: SemanticDocument): Patch = {
     doc.tree.collect {
+      case t @ Term.Apply(Term.Apply(x1, args: List[_]), List(Lit.Int(0))) =>
+        try {
+          if (x1.symbol.isAssignableTo(Seq.getClass)
+            || (!x1.symbol.isAssignableTo(List.getClass))) {
+            Patch.replaceTree(
+              t,
+              Term.Select(Term.Apply(x1, args), Term.Name("head")).toString
+            )
+          } else {
+            Patch.empty
+          }
+        } catch {
+          case _: Throwable => Patch.empty
+        }
       case t @ Term.Apply(x1, List(Lit.Int(0))) =>
         try {
           if (x1.symbol.isAssignableTo(classOf[collection.Seq[Any]])

--- a/rules/src/test/scala/util/SemanticTypeConverterTest.scala
+++ b/rules/src/test/scala/util/SemanticTypeConverterTest.scala
@@ -30,6 +30,10 @@ class SemanticTypeConverterTest extends AnyFunSuite {
     assert(classOf[Seq[_]] == SemanticTypeConverter.symbolToClass(scalafix.v1.Symbol("scala/collection/Seq#")))
   }
 
+  test("symbolToClass: オブジェクトを取得できる") {
+    assert(Seq.getClass == SemanticTypeConverter.symbolToClass(scalafix.v1.Symbol("scala/collection/Seq.")))
+  }
+
   test("symbolToClass: 型パラメータを持つクラス名を取得できる") {
     assert(
       classOf[List[_]] == SemanticTypeConverter.symbolToClass(scalafix.v1.Symbol("scala/collection/immutable/List#[T]"))


### PR DESCRIPTION
以下のようなコードは `Seq$ # apply` を利用したインスタンス生成だが、これまでクラスとコンパニオンオブジェクトの区別を行なっていなかったため、 `Seq.head` に変換されてしまう問題があった。

```scala
val seq = Seq(0)
```

コンパニオンオブジェクトを区別できるように `SemanticConverter` を修正した上で、該当するオブジェクトの `Class<?>` を直接比較するようにした (e.g. `List.getClass` )