### PR TITLE
add: ScalatestのassertThrowsをinterceptに変更するルールの作成

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -137,3 +137,21 @@ when(a.fuga).thenReturn("mock")
  * Mockito.doReturn("mock").when(a).fuga
  */
 ```
+
+## fix.pixiv.ScalatestAssertThrowsToIntercept
+Unify the assertion of Exceptions for using [Scalatest](https://www.scalatest.org/).
+
+In the case of Exception assertion in article [using_assertions](https://www.scalatest.org/user_guide/using_assertions), there are `assertThrows` and `intercept` that difference between `assertThrows` and `intercept` is `intercept` returns Exceptions but `assertThrows` does not.
+Applying this rule changes `assertThrows` to `intercept`.
+```scala
+/* rule = ScalatestAssertThrowsToIntercept */
+assertThrows[RuntimeException]{
+  a.hoge()
+}
+
+/* rewrite to:
+ * intercept[RuntimeException]{
+ *   a.hoge()
+ * }
+ */
+```

--- a/README.md
+++ b/README.md
@@ -133,3 +133,21 @@ when(a.fuga).thenReturn("mock")
  * Mockito.doReturn("mock").when(a).fuga
  */
 ```
+
+## fix.pixiv.ScalatestAssertThrowsToIntercept
+[Scalatest](https://www.scalatest.org/)のExceptionのassertionを統一します。
+
+[using_assertions](https://www.scalatest.org/user_guide/using_assertions)のドキュメントで、Exceptionsのassertionの場合には`assertThrows`と`intercept`がありますが、 二つの違いは`intercept`はExceptionsを値として返し、`assertThrows`は返さないという振る舞いをします。
+このルールでは`assertThrows`を`intercept`に変更するものです。
+```scala
+/* rule = ScalatestAssertThrowsToIntercept */
+assertThrows[RuntimeException]{
+  a.hoge()
+}
+
+/* rewrite to:
+ * intercept[RuntimeException]{
+ *   a.hoge()
+ * }
+ */
+```

--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,7 @@ lazy val input = projectMatrix
     publish / skip := true,
     libraryDependencies ++= Seq(
       "org.mockito" % "mockito-core" % "4.8.1",
-      "org.scalatest" %% "scalatest" % "3.2.11"
+      "org.scalatest" %% "scalatest" % "3.2.15"
     )
   )
   .defaultAxes(VirtualAxis.jvm)
@@ -89,7 +89,7 @@ lazy val output = projectMatrix
     publish / skip := true,
     libraryDependencies ++= Seq(
       "org.mockito" % "mockito-core" % "4.8.1",
-      "org.scalatest" %% "scalatest" % "3.2.11"
+      "org.scalatest" %% "scalatest" % "3.2.15"
     )
   )
   .defaultAxes(VirtualAxis.jvm)

--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,10 @@ lazy val rules = projectMatrix
 lazy val input = projectMatrix
   .settings(
     publish / skip := true,
-    libraryDependencies += "org.mockito" % "mockito-core" % "4.8.1"
+    libraryDependencies ++= Seq(
+      "org.mockito" % "mockito-core" % "4.8.1",
+      "org.scalatest" %% "scalatest" % "3.2.11"
+    )
   )
   .defaultAxes(VirtualAxis.jvm)
   .jvmPlatform(scalaVersions = rulesCrossVersions :+ scala3Version)
@@ -84,7 +87,10 @@ lazy val input = projectMatrix
 lazy val output = projectMatrix
   .settings(
     publish / skip := true,
-    libraryDependencies += "org.mockito" % "mockito-core" % "4.8.1"
+    libraryDependencies ++= Seq(
+      "org.mockito" % "mockito-core" % "4.8.1",
+      "org.scalatest" %% "scalatest" % "3.2.11"
+    )
   )
   .defaultAxes(VirtualAxis.jvm)
   .jvmPlatform(scalaVersions = rulesCrossVersions :+ scala3Version)

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val src = (project in file("rules"))
   .settings(
     libraryDependencies ++= Seq(
       "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion,
-      "org.scalatest" %% "scalatest" % "3.2.11" % "test"
+      "org.scalatest" %% "scalatest" % "3.2.15"
     ),
     scalacOptions ++= Seq(
       "-deprecation",
@@ -67,7 +67,7 @@ lazy val rules = projectMatrix
     moduleName := "scalafix-pixiv-rule",
     libraryDependencies ++= Seq(
       "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion,
-      "org.scalatest" %% "scalatest" % "3.2.11" % "test"
+      "org.scalatest" %% "scalatest" % "3.2.15"
     )
   )
   .defaultAxes(VirtualAxis.jvm)

--- a/input/src/main/scala-2.13/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
+++ b/input/src/main/scala-2.13/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
@@ -10,9 +10,9 @@ object ScalatestAssertThrowsToIntercept {
   Assertions.assertThrows[RuntimeException] {
     throw new RuntimeException("assertThrows1")
   }
-  assertThrows[RuntimeException]{
+  assertThrows[RuntimeException] {
     throw new RuntimeException("assertThrows2")
   }
-  //変更なし
+  // 変更なし
   println("assertThrows")
 }

--- a/input/src/main/scala-2.13/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
+++ b/input/src/main/scala-2.13/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
@@ -4,10 +4,14 @@ rule = ScalatestAssertThrowsToIntercept
 package fix.pixiv
 
 import org.scalatest.Assertions
+import org.scalatest.Assertions._
 
 object ScalatestAssertThrowsToIntercept {
-  Assertions.intercept[RuntimeException] {
-    throw new RuntimeException("assertThrows")
+  Assertions.assertThrows[RuntimeException] {
+    throw new RuntimeException("assertThrows1")
+  }
+  assertThrows[RuntimeException]{
+    throw new RuntimeException("assertThrows2")
   }
   //変更なし
   println("assertThrows")

--- a/input/src/main/scala-2.13/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
+++ b/input/src/main/scala-2.13/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
@@ -1,0 +1,14 @@
+/*
+rule = ScalatestAssertThrowsToIntercept
+ */
+package fix.pixiv
+
+import org.scalatest.Assertions
+
+object ScalatestAssertThrowsToIntercept {
+  Assertions.intercept[RuntimeException] {
+    throw new RuntimeException("assertThrows")
+  }
+  //変更なし
+  println("assertThrows")
+}

--- a/output/src/main/scala-2.13/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
+++ b/output/src/main/scala-2.13/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
@@ -1,10 +1,14 @@
 package fix.pixiv
 
 import org.scalatest.Assertions
+import org.scalatest.Assertions._
 
 object ScalatestAssertThrowsToIntercept {
   Assertions.intercept[RuntimeException] {
-    throw new RuntimeException("assertThrows")
+    throw new RuntimeException("assertThrows1")
+  }
+  intercept[RuntimeException]{
+    throw new RuntimeException("assertThrows2")
   }
   //変更なし
   println("assertThrows")

--- a/output/src/main/scala-2.13/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
+++ b/output/src/main/scala-2.13/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
@@ -7,9 +7,9 @@ object ScalatestAssertThrowsToIntercept {
   Assertions.intercept[RuntimeException] {
     throw new RuntimeException("assertThrows1")
   }
-  intercept[RuntimeException]{
+  intercept[RuntimeException] {
     throw new RuntimeException("assertThrows2")
   }
-  //変更なし
+  // 変更なし
   println("assertThrows")
 }

--- a/output/src/main/scala-2.13/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
+++ b/output/src/main/scala-2.13/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
@@ -1,0 +1,11 @@
+package fix.pixiv
+
+import org.scalatest.Assertions
+
+object ScalatestAssertThrowsToIntercept {
+  Assertions.intercept[RuntimeException] {
+    throw new RuntimeException("assertThrows")
+  }
+  //変更なし
+  println("assertThrows")
+}

--- a/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -6,3 +6,4 @@ fix.pixiv.UnifyEmptyList
 fix.pixiv.SingleConditionMatch
 fix.pixiv.MockitoThenToDo
 fix.pixiv.UnifiedArrow
+fix.pixiv.ScalatestAssertThrowsToIntercept

--- a/rules/src/main/scala/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
+++ b/rules/src/main/scala/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
@@ -1,0 +1,16 @@
+package fix.pixiv
+
+import scala.meta._
+
+import scalafix.Patch
+import scalafix.v1._
+class ScalatestAssertThrowsToIntercept extends SemanticRule("ScalatestAssertThrowsToIntercept") {
+  override def fix(implicit doc: SemanticDocument): Patch = {
+    doc.tree.collect {
+      case t @ q"assertThrows" =>
+        Patch.replaceTree(t, "intercept")
+      case _ => Patch.empty
+    }.asPatch
+  }
+
+}

--- a/rules/src/main/scala/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
+++ b/rules/src/main/scala/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
@@ -2,6 +2,8 @@ package fix.pixiv
 
 import scalafix.Patch
 import scalafix.v1._
+import util.SymbolConverter.SymbolToSemanticType
+import org.scalatest.compatible.Assertion
 
 import scala.meta._
 class ScalatestAssertThrowsToIntercept extends SemanticRule("ScalatestAssertThrowsToIntercept") {
@@ -15,7 +17,7 @@ class ScalatestAssertThrowsToIntercept extends SemanticRule("ScalatestAssertThro
     }.asPatch
   }
   private def isAssertThrows(x1: Term)(implicit doc: SemanticDocument): Boolean = {
-    x1.symbol == Symbol("org/scalatest/Assertions#assertThrows().")
+    x1.symbol.isAssignableTo(classOf[Assertion])
   }
 
 }

--- a/rules/src/main/scala/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
+++ b/rules/src/main/scala/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
@@ -17,7 +17,7 @@ class ScalatestAssertThrowsToIntercept extends SemanticRule("ScalatestAssertThro
     }.asPatch
   }
   private def isAssertThrows(x1: Term)(implicit doc: SemanticDocument): Boolean = {
-    x1.symbol.isAssignableTo(classOf[Assertion])
+    x1.symbol.isAssignableFrom(classOf[Assertion])
   }
 
 }

--- a/rules/src/main/scala/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
+++ b/rules/src/main/scala/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
@@ -1,11 +1,11 @@
 package fix.pixiv
 
+import scala.meta._
+
+import org.scalatest.compatible.Assertion
 import scalafix.Patch
 import scalafix.v1._
 import util.SymbolConverter.SymbolToSemanticType
-import org.scalatest.compatible.Assertion
-
-import scala.meta._
 class ScalatestAssertThrowsToIntercept extends SemanticRule("ScalatestAssertThrowsToIntercept") {
   override def fix(implicit doc: SemanticDocument): Patch = {
     doc.tree.collect {

--- a/rules/src/main/scala/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
+++ b/rules/src/main/scala/fix/pixiv/ScalatestAssertThrowsToIntercept.scala
@@ -1,16 +1,21 @@
 package fix.pixiv
 
-import scala.meta._
-
 import scalafix.Patch
 import scalafix.v1._
+
+import scala.meta._
 class ScalatestAssertThrowsToIntercept extends SemanticRule("ScalatestAssertThrowsToIntercept") {
   override def fix(implicit doc: SemanticDocument): Patch = {
     doc.tree.collect {
-      case t @ q"assertThrows" =>
-        Patch.replaceTree(t, "intercept")
+      case Term.ApplyType(name @ Term.Name("assertThrows"), List(_)) if isAssertThrows(name) =>
+        Patch.replaceTree(name, "intercept")
+      case Term.Select(Term.Name("Assertions"), name @ Term.Name("assertThrows")) if isAssertThrows(name) =>
+        Patch.replaceTree(name, "intercept")
       case _ => Patch.empty
     }.asPatch
+  }
+  private def isAssertThrows(x1: Term)(implicit doc: SemanticDocument): Boolean = {
+    x1.symbol == Symbol("org/scalatest/Assertions#assertThrows().")
   }
 
 }

--- a/tests/src/test/scala/fix/RuleSuite.scala
+++ b/tests/src/test/scala/fix/RuleSuite.scala
@@ -1,8 +1,8 @@
 package fix
 
 import scalafix.testkit._
-import org.scalatest.FunSuiteLike
+import org.scalatest.funsuite.AnyFunSuiteLike
 
-class RuleSuite extends AbstractSemanticRuleSuite with FunSuiteLike {
+class RuleSuite extends AbstractSemanticRuleSuite with AnyFunSuiteLike {
   runAllTests()
 }


### PR DESCRIPTION
## fix.pixiv.ScalatestAssertThrowsToInterceptのruleの追加
[Scalatest](https://www.scalatest.org/)のExceptionのassertionを統一します。

[using_assertions](https://www.scalatest.org/user_guide/using_assertions)のドキュメントで、Exceptionsのassertionの場合には`assertThrows`と`intercept`がありますが、 二つの違いは`intercept`はExceptionsを値として返し、`assertThrows`は返さないという振る舞いをします。
このルールでは`assertThrows`を`intercept`に変更するものです。
```scala
/* rule = ScalatestAssertThrowsToIntercept */
assertThrows[RuntimeException]{
  a.hoge()
}
/* rewrite to:
 * intercept[RuntimeException]{
 *   a.hoge()
 * }
 */
```