### PR TITLE
CIのscalafmtCheckAllからinputを対象外とした

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
       - name: scalafix
         run: sbt "+src/scalafix --check"
       - name: scalafmt
-        run: sbt scalafmtSbtCheck "src/scalafmtCheckAll" "input2_13/scalafmtCheckAll" "input2_12/scalafmtCheckAll"
+        run: sbt scalafmtSbtCheck "src/scalafmtCheckAll"
       - name: Test
         run: sbt test


### PR DESCRIPTION
scalafmtとscalafixでスペースの取り扱いでコンフリクトが起きるので、一旦inputはfmt対象から外すことで対処した

ref: https://github.com/pixiv/scalafix-pixiv-rule/pull/64/commits/a7b93a75321430434dee5c2d2802b85670ea50f1#diff-7e25b445991eaba735fd770e1ddcf8f778bd299b9783f7f956d8c9315c3866f4L8-R8