### PR TITLE
feat: Lint ルールで利用できる汎用ログレベルコンフィグを定義

### DIFF
--- a/rules/src/main/scala/fix/pixiv/LogConfig.scala
+++ b/rules/src/main/scala/fix/pixiv/LogConfig.scala
@@ -1,0 +1,14 @@
+package fix.pixiv
+
+import metaconfig.ConfDecoder
+import metaconfig.generic.Surface
+
+final case class LogConfig(
+    level: String = "Warn"
+)
+
+object LogConfig {
+  val default: LogConfig = LogConfig()
+  implicit val surface: Surface[LogConfig] = metaconfig.generic.deriveSurface[LogConfig]
+  implicit val decoder: ConfDecoder[LogConfig] = metaconfig.generic.deriveDecoder(default)
+}

--- a/rules/src/main/scala/fix/pixiv/LogLevel.scala
+++ b/rules/src/main/scala/fix/pixiv/LogLevel.scala
@@ -1,0 +1,15 @@
+package fix.pixiv
+
+import scala.meta.Position
+
+import scalafix.lint.{Diagnostic, LintSeverity}
+
+case class LogLevel(override val message: String, override val position: Position, level: String) extends Diagnostic {
+  override def severity: LintSeverity = level match {
+    case "Info" => LintSeverity.Info
+    case "Warn" => LintSeverity.Warning
+    case "Error" => LintSeverity.Error
+    // 設定に異常値が入っている場合はデフォルトとして扱う
+    case _ => LintSeverity.Warning
+  }
+}

--- a/rules/src/main/scala/fix/pixiv/NonCaseException.scala
+++ b/rules/src/main/scala/fix/pixiv/NonCaseException.scala
@@ -1,20 +1,26 @@
 package fix.pixiv
 
-import scala.meta.{Defn, Init, Mod, Position, Template}
+import scala.meta.{Defn, Init, Mod, Template}
 
+import metaconfig.Configured
 import scalafix.Patch
-import scalafix.lint.{Diagnostic, LintSeverity}
-import scalafix.v1.{SemanticDocument, SemanticRule, XtensionTreeScalafix}
+import scalafix.v1.{Configuration, Rule, SemanticDocument, SemanticRule, XtensionTreeScalafix}
 import util.SymbolConverter.SymbolToSemanticType
 
-class NonCaseException extends SemanticRule("NonCaseException") {
+class NonCaseException(config: LogConfig) extends SemanticRule("NonCaseException") {
+  def this() = this(LogConfig())
+
+  override def withConfiguration(config: Configuration): Configured[Rule] = {
+    config.conf.getOrElse("NonCaseException")(this.config)
+      .map { newConfig => new NonCaseException(newConfig) }
+  }
 
   override def fix(implicit doc: SemanticDocument): Patch = {
     doc.tree.collect {
       case t @ Defn.Class(List(_: Mod.Case), name, _, _, _ @Template(_, List(_ @Init(typ, _, _)), _, _)) =>
         try {
           if (typ.symbol.isAssignableTo(classOf[Exception])) {
-            Patch.lint(NonCaseExceptionError(s"case class として Exception を継承することは推奨されません: $name", t.pos))
+            Patch.lint(LogLevel(s"case class として Exception を継承することは推奨されません: $name", t.pos, config.level))
           } else {
             Patch.empty
           }
@@ -23,8 +29,4 @@ class NonCaseException extends SemanticRule("NonCaseException") {
         }
     }.asPatch
   }
-}
-
-case class NonCaseExceptionError(override val message: String, position: Position) extends Diagnostic {
-  override def severity: LintSeverity = LintSeverity.Error
 }


### PR DESCRIPTION
```:.scalafix.conf
NonCaseException {
  level = "Warn" // "Info" or "Error" も利用できる
}
```