### PR TITLE
feat: 不適切なパッケージに特定規則のクラス名がある場合に警告するルールの追加

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -168,3 +168,22 @@ class RedException extends RuntimeException {}
 RuntimeException を継承したクラスを作る際にはメッセージを付与してください: RedException
  */
 ```
+
+## fix.pixiv.NamingConventionPackage
+Generates a warning when a class that follows a certain naming convention is found in an inappropriate package.
+
+For example, when using the [Play Framework](https://www.playframework.com/documentation/2.8.x/Anatomy), 
+a class named Controller is required to not be in the filters directory.
+
+```scala
+/*
+rule = NamingConventionPackage
+NamingConventionPackage.convention = [
+  { package = "^filters$", class = "^.+Controller$" }
+]
+ */
+package filters
+
+// class HomeController は filters パッケージに実装すべきではありません
+class HomeController {}
+```

--- a/README.md
+++ b/README.md
@@ -164,3 +164,22 @@ class RedException extends RuntimeException {}
 RuntimeException を継承したクラスを作る際にはメッセージを付与してください: RedException
  */
 ```
+
+## fix.pixiv.NamingConventionPackage
+ある命名規則に倣ったクラスが適切でないパッケージにある場合に警告を発生させます。
+
+例えば、 [Play Framework](https://www.playframework.com/documentation/2.8.x/Anatomy) を利用している場合に、
+`Controller` と命名されたクラスが `filters` ディレクトリをないことを要求します。
+
+```scala
+/*
+rule = NamingConventionPackage
+NamingConventionPackage.convention = [
+  { package = "^filters$", class = "^.+Controller$" }
+]
+ */
+package filters
+
+// class HomeController は filters パッケージに実装すべきではありません
+class HomeController {}
+```

--- a/input/src/main/scala/fix/pixiv/NamingConventionPackage.scala
+++ b/input/src/main/scala/fix/pixiv/NamingConventionPackage.scala
@@ -1,7 +1,7 @@
 /*
 rule = NamingConventionPackage
 NamingConventionPackage.convention = [
-  ["^.+\\.pixiv$", "^.+Package$"]
+  { package = "^.+\\.pixiv$", class = "^.+Package$" }
 ]
  */
 package fix.pixiv

--- a/input/src/main/scala/fix/pixiv/NamingConventionPackage.scala
+++ b/input/src/main/scala/fix/pixiv/NamingConventionPackage.scala
@@ -1,0 +1,15 @@
+/*
+rule = NamingConventionPackage
+NamingConventionPackage.convention = [
+  ["^.+\\.pixiv$", "^.+Package$"]
+]
+ */
+package fix.pixiv
+
+class NamingConventionPackage /* assert: NamingConventionPackage
+^
+class NamingConventionPackage は fix.pixiv パッケージに実装すべきではありません
+*/
+ extends AnyRef {
+  val value: String = "string"
+}

--- a/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -8,3 +8,4 @@ fix.pixiv.MockitoThenToDo
 fix.pixiv.UnifiedArrow
 fix.pixiv.ScalatestAssertThrowsToIntercept
 fix.pixiv.NeedMessageExtendsRuntimeException
+fix.pixiv.NamingConventionPackage

--- a/rules/src/main/scala/fix/pixiv/NamingConventionPackage.scala
+++ b/rules/src/main/scala/fix/pixiv/NamingConventionPackage.scala
@@ -1,0 +1,47 @@
+package fix.pixiv
+
+import scala.meta.{Defn, Pkg}
+import scala.util.matching.Regex
+
+import metaconfig.Configured
+import scalafix.Patch
+import scalafix.v1.{Configuration, Rule, SemanticDocument, SemanticRule}
+
+class NamingConventionPackage(config: LogConfig, namingConventionPackageConfig: NamingConventionPackageConfig)
+    extends SemanticRule("NamingConventionPackage") {
+  def this() = this(LogConfig(), NamingConventionPackageConfig())
+
+  override def withConfiguration(config: Configuration): Configured[Rule] = {
+    (config.conf.getOrElse("NamingConventionPackage")(this.config) |@| config.conf.getOrElse("NamingConventionPackage")(
+      this.namingConventionPackageConfig
+    ))
+      .map {
+        case (config, config1) => new NamingConventionPackage(config, config1)
+      }
+  }
+
+  private val patterns: List[(Regex, Regex)] = namingConventionPackageConfig.convention.map {
+    case key :: value :: _ => key.r -> value.r
+  }
+
+  override def fix(implicit doc: SemanticDocument): Patch = {
+    doc.tree.collect {
+      case Pkg(packageName, list) =>
+        list.map {
+          case t @ Defn.Class(_, className, _, _, _) =>
+            patterns.find {
+              case (pkg, cls) =>
+                pkg.findFirstIn(packageName.toString()).nonEmpty && cls.findFirstIn(className.value).nonEmpty
+            }.fold(Patch.empty) { _: (Regex, Regex) =>
+              Patch.lint(LogLevel(
+                s"class ${className.value} は ${packageName.toString()} パッケージに実装すべきではありません",
+                t.pos,
+                config.level
+              ))
+            }
+          case _ => Patch.empty
+        }.asPatch
+    }.asPatch
+  }
+
+}

--- a/rules/src/main/scala/fix/pixiv/NamingConventionPackage.scala
+++ b/rules/src/main/scala/fix/pixiv/NamingConventionPackage.scala
@@ -20,8 +20,13 @@ class NamingConventionPackage(config: LogConfig, namingConventionPackageConfig: 
       }
   }
 
-  private val patterns: List[(Regex, Regex)] = namingConventionPackageConfig.convention.map {
-    case key :: value :: _ => key.r -> value.r
+  private val patterns: List[(Regex, Regex)] = namingConventionPackageConfig.convention.map { map =>
+    val (pkg, cls) = (for {
+      pkg <- map.get("package")
+      cls <- map.get("class")
+    } yield (pkg, cls))
+      .getOrElse(throw new RuntimeException(s"Config の指定が不正です: ${map.mkString(", ")}"))
+    pkg.r -> cls.r
   }
 
   override def fix(implicit doc: SemanticDocument): Patch = {

--- a/rules/src/main/scala/fix/pixiv/NamingConventionPackageConfig.scala
+++ b/rules/src/main/scala/fix/pixiv/NamingConventionPackageConfig.scala
@@ -1,10 +1,9 @@
 package fix.pixiv
-
 import metaconfig.ConfDecoder
 import metaconfig.generic.Surface
 
 case class NamingConventionPackageConfig(
-    convention: List[List[String]] = List.empty
+    convention: List[Map[String, String]] = List.empty
 )
 
 object NamingConventionPackageConfig {

--- a/rules/src/main/scala/fix/pixiv/NamingConventionPackageConfig.scala
+++ b/rules/src/main/scala/fix/pixiv/NamingConventionPackageConfig.scala
@@ -1,0 +1,15 @@
+package fix.pixiv
+
+import metaconfig.ConfDecoder
+import metaconfig.generic.Surface
+
+case class NamingConventionPackageConfig(
+    convention: List[List[String]] = List.empty
+)
+
+object NamingConventionPackageConfig {
+  val default: NamingConventionPackageConfig = NamingConventionPackageConfig()
+  implicit val surface: Surface[NamingConventionPackageConfig] =
+    metaconfig.generic.deriveSurface[NamingConventionPackageConfig]
+  implicit val decoder: ConfDecoder[NamingConventionPackageConfig] = metaconfig.generic.deriveDecoder(default)
+}


### PR DESCRIPTION
```scala
/*
rule = NamingConventionPackage
NamingConventionPackage.convention = [
  ["^.+\\.pixiv$", "^.+Package$"]
]
 */
package fix.pixiv

class NamingConventionPackage /*
^
class NamingConventionPackage は fix.pixiv パッケージに実装すべきではありません
*/
 extends AnyRef {
  val value: String = "string"
}
```