### PR TITLE
feat: 不適切な import 警告の実装

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -203,3 +203,20 @@ import javax.inject.Inject // rewrite to: import jakarta.inject.Inject
 class PackageJavaxToJakarta @Inject()() {
 }
 ```
+
+## fix.pixiv.ShouldNotImportPackage
+
+Warn when a package following a certain naming convention is `import` from an inappropriate package.
+
+```scala
+/*
+rule = ShouldNotImportPackage
+ShouldNotImportPackage.blackList = [
+  { target = "^.+\\.infrastructures.*", importer = "^.+\\.models.*" }
+]
+ */
+package models
+
+// infrastructures は models から呼び出されるべきではありません
+import infrastructures
+```

--- a/README.md
+++ b/README.md
@@ -200,3 +200,20 @@ import javax.inject.Inject // rewrite to: import jakarta.inject.Inject
 class PackageJavaxToJakarta @Inject()() {
 }
 ```
+
+## fix.pixiv.ShouldNotImportPackage
+
+ある命名規則に倣ったパッケージが適切でないパッケージから `import` されている場合に警告を行います。
+
+```scala
+/*
+rule = ShouldNotImportPackage
+ShouldNotImportPackage.blackList = [
+  { target = "^.+\\.infrastructures.*", importer = "^.+\\.models.*" }
+]
+ */
+package models
+
+// infrastructures は models から呼び出されるべきではありません
+import infrastructures
+```

--- a/input/src/main/scala/fix/pixiv/ShouldNotImportPackage.scala
+++ b/input/src/main/scala/fix/pixiv/ShouldNotImportPackage.scala
@@ -1,0 +1,17 @@
+/*
+rule = ShouldNotImportPackage
+ShouldNotImportPackage.blackList = [
+  { target = "^scala\\.collection\\.mutable.*$", importer = "^.+\\.pixiv$" }
+]
+ */
+package fix.pixiv
+
+import scala.collection.mutable/* assert: ShouldNotImportPackage
+       ^^^^^^^^^^^^^^^^^^^^^^^^
+scala.collection.mutable は fix.pixiv から呼び出されるべきではありません
+*/
+
+class ShouldNotImportPackage
+ extends AnyRef {
+  val map: mutable.Map[String, String] = mutable.Map("key" -> "value")
+}

--- a/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -10,3 +10,4 @@ fix.pixiv.ScalatestAssertThrowsToIntercept
 fix.pixiv.NeedMessageExtendsRuntimeException
 fix.pixiv.NamingConventionPackage
 fix.pixiv.PackageJavaxToJakarta
+fix.pixiv.ShouldNotImportPackage

--- a/rules/src/main/scala/fix/pixiv/ShouldNotImportPackage.scala
+++ b/rules/src/main/scala/fix/pixiv/ShouldNotImportPackage.scala
@@ -1,0 +1,63 @@
+package fix.pixiv
+
+import scala.meta.{Importer, Pkg}
+
+import metaconfig.Configured
+import scalafix.Patch
+import scalafix.v1.{Configuration, Rule, SemanticDocument, SemanticRule}
+
+class ShouldNotImportPackage(config: LogConfig, shouldNotImportPackageConfig: ShouldNotImportPackageConfig)
+    extends SemanticRule("ShouldNotImportPackage") {
+  def this() = this(LogConfig(), ShouldNotImportPackageConfig())
+
+  override def withConfiguration(config: Configuration): Configured[Rule] = {
+    (config.conf.getOrElse("ShouldNotImportPackage")(this.config) |@| config.conf.getOrElse("ShouldNotImportPackage")(
+      this.shouldNotImportPackageConfig
+    ))
+      .map {
+        case (config, config1) => new ShouldNotImportPackage(config, config1)
+      }
+  }
+
+  private val patterns: Map[String, List[String]] = shouldNotImportPackageConfig.blackList.map { map =>
+    val (target, importer) = (for {
+      target <- map.get("target")
+      importer <- map.get("importer")
+    } yield (target, importer))
+      .getOrElse(throw new RuntimeException(s"Config の指定が不正です: ${map.mkString(", ")}"))
+    importer -> target
+  }.foldLeft(Map.empty[String, List[String]]) {
+    case (map, (importer, target)) => map + (importer -> List(target))
+  }
+
+  override def fix(implicit doc: SemanticDocument): Patch = {
+    doc.tree.collect {
+      // package 宣言を取得
+      case Pkg(packageName, _) => packageName.toString()
+    } match {
+      // 1つだけの場合、 importer にマッチするものを絞り込み
+      case List(packageName) =>
+        patterns.find {
+          case (importer, _) => importer.r.findFirstIn(packageName).nonEmpty
+        } match {
+          case Some((_, targets)) =>
+            doc.tree.collect {
+              case i: Importer =>
+                val regex = targets.find {
+                  _.r.findFirstIn(i.toString()).nonEmpty
+                }
+                if (regex.isDefined) {
+                  Patch.lint(LogLevel(
+                    s"${i.toString()} は $packageName から呼び出されるべきではありません",
+                    i.pos,
+                    config.level
+                  ))
+                } else Patch.empty
+              case _ => Patch.empty
+            }.asPatch
+          case None => Patch.empty
+        }
+      case _ => Patch.empty
+    }
+  }
+}

--- a/rules/src/main/scala/fix/pixiv/ShouldNotImportPackageConfig.scala
+++ b/rules/src/main/scala/fix/pixiv/ShouldNotImportPackageConfig.scala
@@ -1,0 +1,15 @@
+package fix.pixiv
+
+import metaconfig.ConfDecoder
+import metaconfig.generic.Surface
+
+case class ShouldNotImportPackageConfig(
+    blackList: List[Map[String, String]] = List.empty
+)
+
+object ShouldNotImportPackageConfig {
+  val default: ShouldNotImportPackageConfig = ShouldNotImportPackageConfig()
+  implicit val surface: Surface[ShouldNotImportPackageConfig] =
+    metaconfig.generic.deriveSurface[ShouldNotImportPackageConfig]
+  implicit val decoder: ConfDecoder[ShouldNotImportPackageConfig] = metaconfig.generic.deriveDecoder(default)
+}


### PR DESCRIPTION
ある命名規則に倣ったパッケージが適切でないパッケージから `import` されている場合に警告を行います。

```scala
/*
rule = ShouldNotImportPackage
ShouldNotImportPackage.blackList = [
  { target = "^.+\\.infrastructures.*", importer = "^.+\\.models.*" }
]
 */
package models

// infrastructures は models から呼び出されるべきではありません
import infrastructures
```